### PR TITLE
📝 Filter out other users' comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ POLLY_MERGE_BITBUCKET_URL=<your url>
 # defaults to "@polly merge"
 POLLY_MERGE_TRIGGER_COMMENT=<your trigger comment>
 
+# if provided, comments not written by the given user will be ignored
+POLLY_MERGE_BITBUCKET_USERNAME=<your username (e.g. jdoe)>
+
 # if POLLY_MERGE_LOG_FILE is unset, defaults to stdout
 POLLY_MERGE_LOG_FILE=<your log file location>
 */5 * * * * ~/polly-merge/polly-merge.py


### PR DESCRIPTION
If a username is provided via the environment variable
`POLLY_MERGE_BITBUCKET_USERNAME`, do not look for the merge trigger in
comments written by other users.