### PR TITLE
🧑 only trigger on comments from the current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ POLLY_MERGE_BITBUCKET_URL=<your url>
 # defaults to "@polly merge"
 POLLY_MERGE_TRIGGER_COMMENT=<your trigger comment>
 
+# if provided, comments from any user can trigger the action,
+# instead of just the authenticated user
+POLLY_MERGE_ANY_USER_COMMENT=<1 to enable, or unset to disable>
+
 # if POLLY_MERGE_LOG_FILE is unset, defaults to stdout
 POLLY_MERGE_LOG_FILE=<your log file location>
 */5 * * * * ~/polly-merge/polly-merge.py


### PR DESCRIPTION
Add an option variable `POLLY_MERGE_ANY_USER_COMMENT` to trigger on
comments from any user, but by default now only trigger on comments from
the current authenticated user.

All credit to @kesyog for this idea, thank you! 🙇