### PR TITLE
🛠️ support a config ini in addition to env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN apt-get update && apt-get -y install \
 
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update && apt-get -y install \
-    python2.7 \
-    python3.6 \
     python3.7 \
     python3.8
 

--- a/polly-merge.default.ini
+++ b/polly-merge.default.ini
@@ -1,0 +1,13 @@
+# Example ini file; copy to polly-merge.ini and modify any settings
+
+[DEFAULT]
+# api token; mandatory
+bitbucket_api_token=gpAzZ6kW2l5g8jaPjg3qzlQLRUL5pgcyvbskt1Aj7qST
+# bitbucket host url; mandatory
+bitbucket_url=https://example.com
+# set to true to trigger actions on comments by any user
+any_user_comment=false
+# location of the log file. blank means don't log to a log file
+log_file=""
+# prefix to trigger merge
+merge_trigger="@polly"

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,13 @@ requires = [ "setuptools == 40.6.3", "wheel == 0.32.3"]
 [tox]
 isolated_build = True
 envlist =
-    py{36,37,38}
+    py{37,38}
     black
     isort
 
 [testenv]
 deps =
-    py{36,37,38}: pylint==2.5.0
+    py{37,38}: pylint==2.5.0
 setenv =
     TOX_INI_DIR = {toxinidir}
 commands =


### PR DESCRIPTION
Helpful to supply a config file instead of just a gazillion env vars.

Use a dataclass to have a single point of truth for all config options.

Environment vars can override (optional) ini settings.

Uses exclusively built in libraries.

(Generated example api token with this oneliner 😀:

```bash
cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 44 | head -n 1
```
)

Fixes #13.